### PR TITLE
支持int,tinyint,mediumint,smallint,bigint类型设置长度

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 laravel-schema-extend
 =====================
 
+forked from zedisdog/laravel-schema-extend
+
+
 - support MySQL 'table comment'.
-- 因为网上的不支持5.1以后的版本，所以自己改吧
-- 让 laravel 的 Schema 支持 MySQL “表注释”，5.1以后已经内置了列注释。
-
----
-
-> **不会对官方源码照成任何影响。**  
-> 继承原生 schema，随源码更新。  
+- 'int' data type length setting
 
 
 ## 使用前的准备
@@ -17,7 +14,7 @@ laravel-schema-extend
 
 * support laravel 5.*
 ```json
-"zedisdog/laravel-schema-extend": "～0.5"
+"Jialeo/laravel-schema-extend": "～0.5"
 ```
 
 
@@ -27,7 +24,7 @@ laravel-schema-extend
 'aliases' => array(
     ...
     // 'Schema' => Illuminate\Support\Facades\Schema::class,
-    'Schema'    => zedisdog\LaravelSchemaExtend\Schema::class,
+    'Schema'    => Jialeo\LaravelSchemaExtend\Schema::class,
 ),
 ```
 
@@ -37,12 +34,12 @@ laravel-schema-extend
 Schema::create('tests', function ($table) {
     $table->increments('id')->comment('列注释');
     $table->comment = '表注释';
+
+    $table->integer('int')->default(1)->length(1);
+    $table->bigInteger('big')->default(1)->length(1);
+    $table->smallInteger('small')->default(1)->length(1);
+    $table->tinyInteger('tiny')->default(1)->length(1);
+    $table->mediumInteger('medium')->default(1)->length(1);
 });
 ```
 
-## 致谢
-
-- [ghostboyzone](https://github.com/ghostboyzone)
-- [xuhuan](https://github.com/xuhuan)
-- [xiaobeicn](https://github.com/xiaobeicn)
-- [5-say](https://github.com/5-say)

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,19 @@
 {
-    "name" : "zedisdog/laravel-schema-extend",
+    "name" : "jialeo/laravel-schema-extend",
     "type" : "library",
-    "description" : "support MySQL 'table comment'.",
+    "description" : "support MySQL 'table comment','int' data type length setting",
     "authors" : [
         {
-            "name": "zed",
-            "email": "2692273254@qq.com"
+            "name": "chenjialiang",
+            "email": "chenjialiang@han-zi.cn"
         }
     ],
     "require" : {
         "laravel/framework": "5.*"
     },
-    "time" : "2015-11-16",
     "autoload" : {
-        "psr-0" : {
-            "zedisdog\\LaravelSchemaExtend" : "src/"
+        "psr-4" : {
+            "Jialeo\\LaravelSchemaExtend" : "src/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "autoload" : {
         "psr-4" : {
-            "Jialeo\\LaravelSchemaExtend" : "src/"
+            "Jialeo\\LaravelSchemaExtend\\" : "src/"
         }
     }
 }

--- a/src/MySqlGrammar.php
+++ b/src/MySqlGrammar.php
@@ -1,4 +1,4 @@
-<?php namespace zedisdog\LaravelSchemaExtend;
+<?php namespace Jialeo\LaravelSchemaExtend;
 
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Schema\Blueprint;

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1,5 +1,5 @@
 <?php
-namespace zedisdog\LaravelSchemaExtend;
+namespace Jialeo\LaravelSchemaExtend;
 
 use \Illuminate\Support\Facades\Facade;
 

--- a/src/zedisdog/LaravelSchemaExtend/MySqlGrammar.php
+++ b/src/zedisdog/LaravelSchemaExtend/MySqlGrammar.php
@@ -26,4 +26,75 @@ class MySqlGrammar extends BaseMySqlGrammar
         }
         return $sql;
     }
+
+
+    /**
+     * 重载typeInteger
+     * Create the column definition for an integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    public function typeInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'int' . $length_str;
+    }
+
+    /**
+     * 重载typeBigInteger
+     * Create the column definition for a big integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    protected function typeBigInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'bigint' . $length_str;
+    }
+
+    /**
+     * 重载typeMediumInteger
+     * Create the column definition for a medium integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    protected function typeMediumInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'mediumint' . $length_str;
+    }
+
+    /**
+     * 重载typeTinyInteger
+     * Create the column definition for a tiny integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    protected function typeTinyInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'tinyint' . $length_str;
+    }
+
+    /**
+     * 重载typeSmallInteger
+     * Create the column definition for a small integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    protected function typeSmallInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'smallint' . $length_str;
+    }
 }


### PR DESCRIPTION
支持int,tinyint,mediumint,smallint,bigint类型设置长度

使用`->length(1)`来设置以上类型的长度

```php
\Schema::create('test', function (Blueprint $table) {
            $table->increments('id');

            $table->integer('aaa')->default(1)->length(1);
            $table->bigInteger('big')->default(1)->length(1);
            $table->smallInteger('small')->default(1)->length(1);
            $table->tinyInteger('tiny')->default(1)->length(1);
            $table->mediumInteger('medium')->default(1)->length(1);
 });
```