### PR TITLE
支持int,tinyint,mediumint,smallint,bigint类型设置长度

### DIFF
--- a/src/zedisdog/LaravelSchemaExtend/MySqlGrammar.php
+++ b/src/zedisdog/LaravelSchemaExtend/MySqlGrammar.php
@@ -26,4 +26,75 @@ class MySqlGrammar extends BaseMySqlGrammar
         }
         return $sql;
     }
+
+
+    /**
+     * 重载typeInteger
+     * Create the column definition for an integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    public function typeInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'int' . $length_str;
+    }
+
+    /**
+     * 重载typeBigInteger
+     * Create the column definition for a big integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    protected function typeBigInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'bigint' . $length_str;
+    }
+
+    /**
+     * 重载typeMediumInteger
+     * Create the column definition for a medium integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    protected function typeMediumInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'mediumint' . $length_str;
+    }
+
+    /**
+     * 重载typeTinyInteger
+     * Create the column definition for a tiny integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    protected function typeTinyInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'tinyint' . $length_str;
+    }
+
+    /**
+     * 重载typeSmallInteger
+     * Create the column definition for a small integer type.
+     *
+     * @param  \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    protected function typeSmallInteger(Fluent $column)
+    {
+        $length_str = !empty($column->length) ? '(' . $column->length . ')' : '';
+
+        return 'smallint' . $length_str;
+    }
 }


### PR DESCRIPTION
支持int,tinyint,mediumint,smallint,bigint类型设置长度

使用`->length(1)`来设置以上类型的长度

```php
\Schema::create('test', function (Blueprint $table) {
            $table->increments('id');

            $table->integer('aaa')->default(1)->length(1);
            $table->bigInteger('big')->default(1)->length(1);
            $table->smallInteger('small')->default(1)->length(1);
            $table->tinyInteger('tiny')->default(1)->length(1);
            $table->mediumInteger('medium')->default(1)->length(1);
 });
```